### PR TITLE
feat: Add web dashboard for monitoring

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -319,3 +319,15 @@ func (s *slruSegment) accessItem(item *CacheItem) {
 		s.protectedList.MoveToFront(item.element)
 	}
 }
+
+// GetCacheSize returns the number of items in the probation and protected segments.
+func (c *Cache) GetCacheSize() (int, int) {
+	var probationSize, protectedSize int
+	for _, shard := range c.shards {
+		shard.RLock()
+		probationSize += shard.probationList.Len()
+		protectedSize += shard.protectedList.Len()
+		shard.RUnlock()
+	}
+	return probationSize, protectedSize
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,13 +5,14 @@ import "time"
 // Config holds the configuration for the DNS resolver.
 type Config struct {
 	ListenAddr           string
+	DashboardAddr        string
 	UpstreamTimeout      time.Duration
 	RequestTimeout       time.Duration
 	MaxWorkers           int
 	CacheSize            int
 	MessageCacheSize     int
-  RRsetCacheSize       int
-  CacheMaxTTL          time.Duration
+	RRsetCacheSize       int
+	CacheMaxTTL          time.Duration
 	CacheMinTTL          time.Duration
 	StaleWhileRevalidate time.Duration
 	PrefetchInterval     time.Duration
@@ -21,13 +22,14 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		ListenAddr:           "0.0.0.0:5053",
+		DashboardAddr:        "0.0.0.0:8080",
 		UpstreamTimeout:      5 * time.Second,
 		RequestTimeout:       5 * time.Second,
 		MaxWorkers:           100,
 		CacheSize:            50000,
 		MessageCacheSize:     50000,
-  RRsetCacheSize:       50000,
-  CacheMaxTTL:          3600 * time.Second,
+		RRsetCacheSize:       50000,
+		CacheMaxTTL:          3600 * time.Second,
 		CacheMinTTL:          60 * time.Second,
 		StaleWhileRevalidate: 1 * time.Minute,
 		PrefetchInterval:     30 * time.Second,

--- a/internal/dashboard/public/app.js
+++ b/internal/dashboard/public/app.js
@@ -1,0 +1,77 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const qpsValue = document.getElementById('qps-value');
+    const totalQueries = document.getElementById('total-queries');
+    const cacheProbation = document.getElementById('cache-probation');
+    const cacheProtected = document.getElementById('cache-protected');
+
+    const qpsChartCtx = document.getElementById('qps-chart').getContext('2d');
+    const cacheChartCtx = document.getElementById('cache-chart').getContext('2d');
+
+    const qpsChart = new Chart(qpsChartCtx, {
+        type: 'line',
+        data: {
+            labels: Array(60).fill(''),
+            datasets: [{
+                label: 'QPS',
+                data: Array(60).fill(0),
+                borderColor: 'rgba(75, 192, 192, 1)',
+                borderWidth: 1,
+                fill: false,
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+
+    const cacheChart = new Chart(cacheChartCtx, {
+        type: 'line',
+        data: {
+            labels: Array(60).fill(''),
+            datasets: [{
+                label: 'Cache Load',
+                data: Array(60).fill(0),
+                borderColor: 'rgba(153, 102, 255, 1)',
+                borderWidth: 1,
+                fill: false,
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+
+    async function fetchMetrics() {
+        try {
+            const response = await fetch('/metrics');
+            const data = await response.json();
+
+            qpsValue.textContent = data.qps.toFixed(2);
+            totalQueries.textContent = data.total_queries;
+            cacheProbation.textContent = data.cache_probation;
+            cacheProtected.textContent = data.cache_protected;
+
+            updateChart(qpsChart, data.qps_history);
+            updateChart(cacheChart, data.cache_load_history);
+
+        } catch (error) {
+            console.error('Error fetching metrics:', error);
+        }
+    }
+
+    function updateChart(chart, data) {
+        chart.data.datasets[0].data = data;
+        chart.update();
+    }
+
+    setInterval(fetchMetrics, 1000);
+    fetchMetrics();
+});

--- a/internal/dashboard/public/index.html
+++ b/internal/dashboard/public/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ASTRACAT DNS Resolver - Dashboard</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <div class="logo">ASTRACAT RESOLVER RECURSION</div>
+            <div class="qps-container">
+                <h2>QPS: <span id="qps-value">0</span></h2>
+            </div>
+        </header>
+        <main>
+            <div class="charts">
+                <div class="chart-container">
+                    <h3>QPS (Last 60s)</h3>
+                    <canvas id="qps-chart"></canvas>
+                </div>
+                <div class="chart-container">
+                    <h3>Cache Load (Last 60s)</h3>
+                    <canvas id="cache-chart"></canvas>
+                </div>
+            </div>
+            <div class="stats">
+                <div class="stat-box">
+                    <h4>Total Queries</h4>
+                    <p id="total-queries">0</p>
+                </div>
+                <div class="stat-box">
+                    <h4>Cache Probation</h4>
+                    <p id="cache-probation">0</p>
+                </div>
+                <div class="stat-box">
+                    <h4>Cache Protected</h4>
+                    <p id="cache-protected">0</p>
+                </div>
+            </div>
+        </main>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/internal/dashboard/public/styles.css
+++ b/internal/dashboard/public/styles.css
@@ -1,0 +1,83 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f4f7f6;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+}
+
+.logo {
+    font-size: 24px;
+    font-weight: bold;
+    color: #007bff;
+}
+
+.qps-container h2 {
+    font-size: 28px;
+    color: #333;
+    margin: 0;
+}
+
+#qps-value {
+    color: #28a745;
+    font-weight: bold;
+}
+
+.charts {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.chart-container {
+    background-color: #fcfcfc;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+}
+
+.stat-box {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.stat-box h4 {
+    margin: 0 0 10px 0;
+    font-size: 18px;
+    color: #666;
+}
+
+.stat-box p {
+    margin: 0;
+    font-size: 24px;
+    font-weight: bold;
+    color: #007bff;
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+// Metrics holds the collected metrics.
+type Metrics struct {
+	sync.RWMutex
+	qps              float64
+	totalQueries     int64
+	startTime        time.Time
+	CacheProbation   int
+	CacheProtected   int
+	qpsHistory       []float64
+	cacheLoadHistory []float64
+}
+
+var (
+	instance *Metrics
+	once     sync.Once
+)
+
+// NewMetrics returns the singleton instance of Metrics.
+func NewMetrics() *Metrics {
+	once.Do(func() {
+		instance = &Metrics{
+			startTime:        time.Now(),
+			qpsHistory:       make([]float64, 0, 60), // Store last 60 seconds
+			cacheLoadHistory: make([]float64, 0, 60),
+		}
+		go instance.qpsCalculator()
+		go instance.cacheLoadCalculator()
+	})
+	return instance
+}
+
+// IncrementQueries increments the total number of queries.
+func (m *Metrics) IncrementQueries() {
+	m.Lock()
+	defer m.Unlock()
+	m.totalQueries++
+}
+
+// qpsCalculator calculates the QPS every second.
+func (m *Metrics) qpsCalculator() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	var lastQueryCount int64
+	for range ticker.C {
+		m.Lock()
+		currentQueries := m.totalQueries
+		// elapsed := time.Since(m.startTime).Seconds()
+		// if elapsed == 0 {
+		// 	m.qps = 0
+		// } else {
+		// 	m.qps = float64(m.totalQueries) / elapsed
+		// }
+		qps := float64(currentQueries - lastQueryCount)
+		m.qps = qps
+		lastQueryCount = currentQueries
+
+		m.qpsHistory = append(m.qpsHistory, m.qps)
+		if len(m.qpsHistory) > 60 {
+			m.qpsHistory = m.qpsHistory[1:]
+		}
+		m.Unlock()
+	}
+}
+
+// cacheLoadCalculator calculates the cache load every second.
+func (m *Metrics) cacheLoadCalculator() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		m.Lock()
+		totalCache := m.CacheProbation + m.CacheProtected
+		m.cacheLoadHistory = append(m.cacheLoadHistory, float64(totalCache))
+		if len(m.cacheLoadHistory) > 60 {
+			m.cacheLoadHistory = m.cacheLoadHistory[1:]
+		}
+		m.Unlock()
+	}
+}
+
+// GetStats returns the current statistics.
+func (m *Metrics) GetStats() (float64, int64, int, int, []float64, []float64) {
+	m.RLock()
+	defer m.RUnlock()
+	return m.qps, m.totalQueries, m.CacheProbation, m.CacheProtected, m.qpsHistory, m.cacheLoadHistory
+}
+
+// UpdateCacheStats updates the cache statistics.
+func (m *Metrics) UpdateCacheStats(probation, protected int) {
+	m.Lock()
+	defer m.Unlock()
+	m.CacheProbation = probation
+	m.CacheProtected = protected
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,24 +1,71 @@
 package server
 
 import (
+	"context"
 	"log"
+	"sync"
+	"time"
 
 	"dns-resolver/internal/config"
+	"dns-resolver/internal/metrics"
+	"dns-resolver/internal/resolver"
 	"github.com/miekg/dns"
 )
 
+var msgPool = sync.Pool{
+	New: func() interface{} {
+		return new(dns.Msg)
+	},
+}
+
 // Server holds the server state.
 type Server struct {
-	config  *config.Config
-	handler dns.Handler
+	config   *config.Config
+	handler  dns.Handler
+	metrics  *metrics.Metrics
+	resolver *resolver.Resolver
 }
 
 // NewServer creates a new server.
-func NewServer(cfg *config.Config) *Server {
+func NewServer(cfg *config.Config, m *metrics.Metrics, res *resolver.Resolver) *Server {
 	s := &Server{
-		config: cfg,
+		config:   cfg,
+		metrics:  m,
+		resolver: res,
 	}
+	s.buildAndSetHandler()
 	return s
+}
+
+func (s *Server) buildAndSetHandler() {
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		req := msgPool.Get().(*dns.Msg)
+		defer func() {
+			*req = dns.Msg{}
+			msgPool.Put(req)
+		}()
+
+		req.SetQuestion(r.Question[0].Name, r.Question[0].Qtype)
+		req.RecursionDesired = true
+		req.SetEdns0(4096, true)
+
+		ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)
+		defer cancel()
+
+		msg, err := s.resolver.Resolve(ctx, req)
+		if err != nil {
+			log.Printf("Failed to resolve %s: %v", req.Question[0].Name, err)
+			dns.HandleFailed(w, r)
+			return
+		}
+
+		msg.Id = r.Id
+
+		if err := w.WriteMsg(msg); err != nil {
+			log.Printf("Failed to write response: %v", err)
+		}
+	})
+	s.handler = s.metricsWrapper(handler)
 }
 
 // ListenAndServe starts the DNS server.
@@ -38,8 +85,10 @@ func (s *Server) startListener(net string) {
 	}
 }
 
-// SetHandler allows replacing the default handler.
-// This will be used to inject the resolver logic later.
-func (s *Server) SetHandler(handler dns.Handler) {
-	s.handler = handler
+// metricsWrapper is a middleware that increments the query counter.
+func (s *Server) metricsWrapper(h dns.Handler) dns.Handler {
+	return dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		s.metrics.IncrementQueries()
+		h.ServeDNS(w, r)
+	})
 }

--- a/main.go
+++ b/main.go
@@ -1,23 +1,17 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
-	"sync"
+	"time"
 
 	"dns-resolver/internal/cache"
 	"dns-resolver/internal/config"
+	"dns-resolver/internal/dashboard"
+	"dns-resolver/internal/metrics"
 	"dns-resolver/internal/resolver"
 	"dns-resolver/internal/server"
-	"github.com/miekg/dns"
 )
-
-var msgPool = sync.Pool{
-	New: func() interface{} {
-		return new(dns.Msg)
-	},
-}
 
 func main() {
 	// Open a file for logging. Truncate the file if it already exists.
@@ -35,6 +29,9 @@ func main() {
 	// Load configuration
 	cfg := config.NewConfig()
 
+	// Initialize metrics
+	m := metrics.NewMetrics()
+
 	// Create cache and resolver
 	c := cache.NewCache(cfg.CacheSize, cache.DefaultShards, cfg.PrefetchInterval)
 	res := resolver.NewResolver(cfg, c)
@@ -42,44 +39,22 @@ func main() {
 	// Set the resolver in the cache for prefetching
 	c.SetResolver(res)
 
+	// Start a goroutine to periodically update cache stats
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			probation, protected := c.GetCacheSize()
+			m.UpdateCacheStats(probation, protected)
+		}
+	}()
+
 	// Create and start the server
-	srv := server.NewServer(cfg)
+	srv := server.NewServer(cfg, m, res)
 
-	// Create a handler function that uses the resolver
-	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		// Get a new dns.Msg from the pool
-		req := msgPool.Get().(*dns.Msg)
-		defer func() {
-			// Reset the message and return it to the pool
-			*req = dns.Msg{}
-			msgPool.Put(req)
-		}()
-
-		// Set up the request message
-		req.SetQuestion(r.Question[0].Name, r.Question[0].Qtype)
-		req.RecursionDesired = true
-		req.SetEdns0(4096, true) // Enable DNSSEC OK bit
-
-		ctx, cancel := context.WithTimeout(context.Background(), cfg.RequestTimeout)
-		defer cancel()
-
-		msg, err := res.Resolve(ctx, req)
-		if err != nil {
-			log.Printf("Failed to resolve %s: %v", req.Question[0].Name, err)
-			dns.HandleFailed(w, r)
-			return
-		}
-
-		// Set the response ID to match the original request ID.
-		msg.Id = r.Id
-
-		if err := w.WriteMsg(msg); err != nil {
-			log.Printf("Failed to write response: %v", err)
-		}
-	})
-
-	// Set the handler on the server
-	srv.SetHandler(handler)
+	// Start the dashboard server
+	dash := dashboard.NewServer(cfg.DashboardAddr, m)
+	go dash.Start()
 
 	srv.ListenAndServe()
 }


### PR DESCRIPTION
This commit introduces a new web dashboard for monitoring the DNS resolver's performance.

The dashboard provides real-time metrics, including:
- Queries Per Second (QPS)
- Total queries
- Cache load (probation and protected)

Key features:
- A web interface with charts for visualizing QPS and cache load over the last 60 seconds.
- The dashboard's listening address and port are configurable via the `DashboardAddr` field in the configuration.
- A new `metrics` package for collecting and managing application metrics.
- A new `dashboard` package with an embedded web server to serve the frontend.
- The frontend assets (HTML, CSS, JS) are embedded into the binary for a self-contained deployment.