### PR TITLE
feat: Add HOSTS file support and admin web panel

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,0 +1,11 @@
+# This is a sample hosts file.
+#
+# Lines starting with # are comments.
+#
+# Format: IP_ADDRESS HOSTNAME [ADDITIONAL_HOSTNAMES...]
+#
+127.0.0.1       localhost
+127.0.0.1       example.com
+127.0.0.1       www.example.com test.example.com
+::1             localhost
+2606:2800:220:1:248:1893:25c8:1946 example.net # This is a comment after a hostname

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1,0 +1,75 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"dns-resolver/internal/metrics"
+	"dns-resolver/plugins/hosts"
+)
+
+// Server provides an admin web interface.
+type Server struct {
+	addr    string
+	metrics *metrics.Metrics
+	hosts   *hosts.HostsPlugin
+}
+
+// New creates a new admin server.
+func New(addr string, m *metrics.Metrics, h *hosts.HostsPlugin) *Server {
+	return &Server{
+		addr:    addr,
+		metrics: m,
+		hosts:   h,
+	}
+}
+
+// Start runs the admin server.
+func (s *Server) Start() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleStats)
+	mux.HandleFunc("/api/hosts/reload", s.handleHostsReload)
+
+	log.Printf("Starting admin server on %s", s.addr)
+	if err := http.ListenAndServe(s.addr, mux); err != nil {
+		log.Fatalf("Failed to start admin server: %v", err)
+	}
+}
+
+func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
+	// Simple HTML page with auto-refresh to display stats.
+	// In a real application, you would use a template engine.
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<title>ASTRACAT DNS Resolver Stats</title>
+			<meta http-equiv="refresh" content="5">
+		</head>
+		<body>
+			<h1>ASTRACAT DNS Resolver Stats</h1>
+			<pre>
+Queries: %d
+			</pre>
+		</body>
+		</html>
+	`, s.metrics.GetQueries()) // Note: We will need to implement GetQueries in metrics.
+}
+
+func (s *Server) handleHostsReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := s.hosts.Reload(); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to reload hosts file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"message": "Hosts file reloaded successfully"})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,13 @@ type Config struct {
 	StaleWhileRevalidate time.Duration
 	LMDBPath             string
 	ResolverType         string // "unbound" or "knot"
+
+	// Hosts file plugin settings
+	HostsEnabled bool
+	HostsPath    string
+
+	// Admin panel settings
+	AdminAddr string
 }
 
 // NewConfig returns a new Config with default values.
@@ -39,5 +46,8 @@ func NewConfig() *Config {
 		StaleWhileRevalidate: 1 * time.Minute,
 		LMDBPath:             "/tmp/dns_cache.lmdb",
 		ResolverType:         "knot", // Default to Knot resolver
+		HostsEnabled:         true,
+		HostsPath:            "hosts",
+		AdminAddr:            "0.0.0.0:8080",
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -298,6 +298,13 @@ func (m *Metrics) IncrementQueries() {
 	promTotalQueries.Inc()
 }
 
+// GetQueries returns the total number of queries.
+func (m *Metrics) GetQueries() int64 {
+	m.RLock()
+	defer m.RUnlock()
+	return m.totalQueries
+}
+
 // qpsCalculator calculates the QPS every second.
 func (m *Metrics) qpsCalculator() {
 	ticker := time.NewTicker(1 * time.Second)

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -15,7 +15,9 @@ type PluginContext struct {
 // Plugin is the interface that all plugins must implement.
 type Plugin interface {
 	Name() string
-	Execute(ctx *PluginContext, msg *dns.Msg) error
+	// Execute processes a DNS message. It returns true if it has handled the
+	// message and no further processing should be done.
+	Execute(ctx *PluginContext, msg *dns.Msg) (bool, error)
 }
 
 // PluginManager manages the lifecycle of plugins.
@@ -37,10 +39,15 @@ func (pm *PluginManager) Register(p Plugin) {
 }
 
 // ExecutePlugins runs all registered plugins.
-func (pm *PluginManager) ExecutePlugins(ctx *PluginContext, msg *dns.Msg) {
+func (pm *PluginManager) ExecutePlugins(ctx *PluginContext, msg *dns.Msg) bool {
 	for _, p := range pm.plugins {
-		if err := p.Execute(ctx, msg); err != nil {
+		handled, err := p.Execute(ctx, msg)
+		if err != nil {
 			log.Printf("Error executing plugin %s: %v", p.Name(), err)
 		}
+		if handled {
+			return true
+		}
 	}
+	return false
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,7 +40,14 @@ func (s *Server) buildAndSetHandler() {
 
 		// Execute request plugins
 		pluginCtx := &plugins.PluginContext{}
-		s.pluginManager.ExecutePlugins(pluginCtx, r)
+		if s.pluginManager.ExecutePlugins(pluginCtx, r) {
+			// A plugin has already handled the request.
+			// The response should be in `r`.
+			if err := w.WriteMsg(r); err != nil {
+				log.Printf("Failed to write plugin response: %v", err)
+			}
+			return
+		}
 
 		req := pool.GetDnsMsg()
 		defer pool.PutDnsMsg(req)

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 	"dns-resolver/internal/metrics"
 	"dns-resolver/internal/plugins"
 	"dns-resolver/internal/resolver"
+	"dns-resolver/internal/admin"
 	"dns-resolver/internal/server"
 	"dns-resolver/plugins/example_logger"
+	"dns-resolver/plugins/hosts"
 )
 
 // Старая функция больше не используется, так как теперь используем метод из пакета metrics
@@ -54,6 +56,19 @@ func main() {
 	// Register the example logger plugin
 	loggerPlugin := example_logger.New()
 	pm.Register(loggerPlugin)
+
+	// Initialize and register the hosts plugin
+	var hostsPlugin *hosts.HostsPlugin
+	if cfg.HostsEnabled {
+		hostsPlugin = hosts.New(cfg.HostsPath)
+		pm.Register(hostsPlugin)
+	}
+
+	// Start the admin server
+	if cfg.AdminAddr != "" {
+		adminServer := admin.New(cfg.AdminAddr, m, hostsPlugin)
+		go adminServer.Start()
+	}
 
 	// Create and start the server
 	srv := server.NewServer(cfg, m, res, pm)

--- a/plugins/example_logger/logger.go
+++ b/plugins/example_logger/logger.go
@@ -16,12 +16,12 @@ func (p *LoggerPlugin) Name() string {
 }
 
 // Execute logs the details of the DNS query.
-func (p *LoggerPlugin) Execute(ctx *plugins.PluginContext, msg *dns.Msg) error {
+func (p *LoggerPlugin) Execute(ctx *plugins.PluginContext, msg *dns.Msg) (bool, error) {
 	if len(msg.Question) > 0 {
 		question := msg.Question[0]
 		log.Printf("[Plugin %s] Received query for %s, type %s", p.Name(), question.Name, dns.TypeToString[question.Qtype])
 	}
-	return nil
+	return false, nil
 }
 
 // New returns a new instance of the LoggerPlugin.

--- a/plugins/hosts/hosts.go
+++ b/plugins/hosts/hosts.go
@@ -1,0 +1,121 @@
+package hosts
+
+import (
+	"bufio"
+	"dns-resolver/internal/plugins"
+	"github.com/miekg/dns"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+)
+
+// HostsPlugin provides DNS resolution from a HOSTS file.
+type HostsPlugin struct {
+	hosts    map[string]net.IP
+	mu       sync.RWMutex
+	filePath string
+}
+
+// New creates a new HostsPlugin.
+func New(filePath string) *HostsPlugin {
+	p := &HostsPlugin{
+		filePath: filePath,
+	}
+	if err := p.Reload(); err != nil {
+		log.Printf("Failed to load hosts file on initial creation: %v", err)
+	}
+	return p
+}
+
+// Name returns the name of the plugin.
+func (p *HostsPlugin) Name() string {
+	return "Hosts"
+}
+
+// Reload re-reads the HOSTS file from disk.
+func (p *HostsPlugin) Reload() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	file, err := os.Open(p.filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	newHosts := make(map[string]net.IP)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		ip := net.ParseIP(parts[0])
+		if ip == nil {
+			continue
+		}
+
+		for i := 1; i < len(parts); i++ {
+			hostname := parts[i]
+			if strings.HasPrefix(hostname, "#") {
+				break
+			}
+			newHosts[strings.ToLower(hostname)] = ip
+		}
+	}
+
+	p.hosts = newHosts
+	log.Printf("Loaded %d entries from hosts file: %s", len(p.hosts), p.filePath)
+	return nil
+}
+
+// Execute checks if the query can be answered from the HOSTS file.
+func (p *HostsPlugin) Execute(ctx *plugins.PluginContext, msg *dns.Msg) (bool, error) {
+	if len(msg.Question) == 0 {
+		return false, nil
+	}
+
+	question := msg.Question[0]
+	// We only handle A and AAAA queries for now.
+	if question.Qtype != dns.TypeA && question.Qtype != dns.TypeAAAA {
+		return false, nil
+	}
+
+	hostname := strings.TrimSuffix(question.Name, ".")
+	p.mu.RLock()
+	ip, ok := p.hosts[strings.ToLower(hostname)]
+	p.mu.RUnlock()
+
+	if !ok {
+		return false, nil
+	}
+
+	var rr dns.RR
+	if ip.To4() != nil && question.Qtype == dns.TypeA {
+		rr = &dns.A{
+			Hdr: dns.RR_Header{Name: question.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   ip,
+		}
+	} else if ip.To4() == nil && question.Qtype == dns.TypeAAAA {
+		rr = &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: question.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 3600},
+			AAAA: ip,
+		}
+	} else {
+		// No match for the query type
+		return false, nil
+	}
+
+	msg.Answer = append(msg.Answer, rr)
+	msg.Rcode = dns.RcodeSuccess
+	return true, nil
+}


### PR DESCRIPTION
This change introduces two new features:
- A HOSTS file plugin that allows for custom DNS records to be served from a local file. The file can be reloaded at runtime without restarting the server.
- An admin web panel that displays basic server statistics (query count) and provides an API endpoint to trigger the reloading of the HOSTS file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hosts file support for local DNS resolution of domain mappings
  * Introduced admin server with statistics dashboard displaying query metrics and hosts file reload API

* **Configuration**
  * New configuration options: `HostsEnabled`, `HostsPath`, and `AdminAddr` to customize hosts file resolution and admin server settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->