### PR TITLE
feat: Добавить статистику и управление плагинами в админ-панель

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 # Ignore compiled binaries
 astracat-dns
 dns-resolver
+
+# Ignore sensitive files
+cookies.txt
+
+# Ignore temporary files
+dashboard.html
+server.log

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"dns-resolver/internal/metrics"
+	"dns-resolver/internal/plugins"
 	"dns-resolver/plugins/adblock"
 	"dns-resolver/plugins/hosts"
 	"golang.org/x/crypto/bcrypt"
@@ -22,6 +23,7 @@ type Server struct {
 	metrics      *metrics.Metrics
 	hosts        *hosts.HostsPlugin
 	adblock      *adblock.AdBlockPlugin
+	pm           *plugins.PluginManager
 	username     string
 	passwordHash []byte
 	sessionToken string
@@ -29,7 +31,7 @@ type Server struct {
 }
 
 // New creates a new admin server.
-func New(addr string, m *metrics.Metrics, h *hosts.HostsPlugin, ab *adblock.AdBlockPlugin) *Server {
+func New(addr string, m *metrics.Metrics, h *hosts.HostsPlugin, ab *adblock.AdBlockPlugin, pm *plugins.PluginManager) *Server {
 	// In a real application, load this from config
 	username := "astracat"
 	password := "astracat"
@@ -43,6 +45,7 @@ func New(addr string, m *metrics.Metrics, h *hosts.HostsPlugin, ab *adblock.AdBl
 		metrics:      m,
 		hosts:        h,
 		adblock:      ab,
+		pm:           pm,
 		username:     username,
 		passwordHash: hash,
 	}
@@ -56,6 +59,9 @@ func (s *Server) Start() {
 
 	// Protected routes
 	mux.Handle("/", s.authMiddleware(http.HandlerFunc(s.handleStats)))
+	mux.Handle("/plugins", s.authMiddleware(http.HandlerFunc(s.handlePlugins)))
+	mux.Handle("/api/plugins/config", s.authMiddleware(http.HandlerFunc(s.handlePluginConfigUpdate)))
+	mux.Handle("/api/metrics", s.authMiddleware(http.HandlerFunc(s.handleApiMetrics)))
 	mux.Handle("/change-password", s.authMiddleware(http.HandlerFunc(s.handleChangePassword)))
 	mux.Handle("/api/hosts/reload", s.authMiddleware(http.HandlerFunc(s.handleHostsReload)))
 	mux.Handle("/adblock/add", s.authMiddleware(http.HandlerFunc(s.handleAddBlocklist)))
@@ -215,6 +221,105 @@ func (s *Server) handleHostsReload(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"message": "Hosts file reloaded successfully"})
 }
 
+func (s *Server) handleApiMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	s.metrics.RLock()
+	defer s.metrics.RUnlock()
+
+	var topNXDomains []metrics.DomainCount
+	s.metrics.TopNXDomains.Range(func(key, value interface{}) bool {
+		topNXDomains = append(topNXDomains, metrics.DomainCount{Domain: key.(string), Count: value.(int64)})
+		return true
+	})
+
+	var topLatencyDomains []metrics.DomainLatency
+	s.metrics.TopLatencyDomains.Range(func(key, value interface{}) bool {
+		stat := value.(metrics.LatencyStat)
+		if stat.Count > 0 {
+			avgLatency := stat.TotalLatency.Seconds() * 1000 / float64(stat.Count)
+			topLatencyDomains = append(topLatencyDomains, metrics.DomainLatency{Domain: key.(string), AvgLatency: avgLatency})
+		}
+		return true
+	})
+
+	var queryTypes []metrics.TypeCount
+	s.metrics.QueryTypes.Range(func(key, value interface{}) bool {
+		queryTypes = append(queryTypes, metrics.TypeCount{Type: key.(string), Count: value.(int64)})
+		return true
+	})
+
+	var responseCodes []metrics.CodeCount
+	s.metrics.ResponseCodes.Range(func(key, value interface{}) bool {
+		responseCodes = append(responseCodes, metrics.CodeCount{Code: key.(string), Count: value.(int64)})
+		return true
+	})
+
+	var cacheHitRate float64
+	if s.metrics.CacheHits+s.metrics.CacheMisses > 0 {
+		cacheHitRate = float64(s.metrics.CacheHits) / float64(s.metrics.CacheHits+s.metrics.CacheMisses) * 100
+	}
+
+	data := metrics.DashboardMetrics{
+		QPS:               s.metrics.QPS,
+		TotalQueries:      s.metrics.GetQueries(),
+		CPUUsage:          s.metrics.CPUUsage,
+		MemoryUsage:       s.metrics.MemoryUsage,
+		Goroutines:        s.metrics.Goroutines,
+		CacheHits:         s.metrics.CacheHits,
+		CacheMisses:       s.metrics.CacheMisses,
+		CacheHitRate:      cacheHitRate,
+		TopNXDomains:      topNXDomains,
+		TopLatencyDomains: topLatencyDomains,
+		QueryTypes:        queryTypes,
+		ResponseCodes:     responseCodes,
+	}
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("Error encoding metrics to JSON: %v", err)
+	}
+}
+
+func (s *Server) handlePlugins(w http.ResponseWriter, r *http.Request) {
+	message := r.URL.Query().Get("message")
+	data := struct {
+		Message string
+		Plugins []plugins.Plugin
+	}{
+		Message: message,
+		Plugins: s.pm.GetPlugins(),
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	tpl, _ := template.New("plugins").Parse(pluginsPage)
+	tpl.Execute(w, data)
+}
+
+func (s *Server) handlePluginConfigUpdate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.ParseForm()
+	pluginName := r.FormValue("pluginName")
+	plugin := s.pm.GetPlugin(pluginName)
+	if plugin == nil {
+		http.Error(w, "Plugin not found", http.StatusNotFound)
+		return
+	}
+
+	config := make(map[string]any)
+	for _, field := range plugin.GetConfigFields() {
+		config[field.Name] = r.FormValue(field.Name)
+	}
+
+	if err := plugin.SetConfig(config); err != nil {
+		http.Redirect(w, r, "/plugins?message=Error+updating+config: "+err.Error(), http.StatusFound)
+		return
+	}
+
+	http.Redirect(w, r, "/plugins?message=Configuration+updated+successfully", http.StatusFound)
+}
+
 const loginPage = `
 <!DOCTYPE html>
 <html lang="en">
@@ -256,6 +361,67 @@ const loginPage = `
 </html>
 `
 
+const pluginsPage = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ASTRACAT DNS - Plugins</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background-color: #f0f2f5; color: #333; }
+        .navbar { background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center; }
+        .navbar .logo { font-size: 1.5rem; font-weight: bold; }
+        .navbar a { text-decoration: none; color: #007bff; }
+		.navbar a:hover { text-decoration: underline; }
+        .container { padding: 2rem; }
+        .card { background: #fff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 1.5rem; padding: 1.5rem; }
+        h1, h2 { color: #333; }
+        .form-group { margin-bottom: 1rem; }
+        .form-group label { display: block; margin-bottom: 0.5rem; }
+        .form-group input, .form-group textarea { width: 100%; max-width: 400px; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        .btn { padding: 0.75rem 1.5rem; border: none; border-radius: 4px; background-color: #007bff; color: white; font-size: 1rem; cursor: pointer; }
+        .btn:hover { background-color: #0056b3; }
+		.message { padding: 1rem; background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; border-radius: 4px; margin-bottom: 1rem; }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <div class="logo">ASTRACAT DNS</div>
+        <div>
+            <a href="/" style="margin-right: 1rem;">Dashboard</a>
+            <a href="/logout">Logout</a>
+        </div>
+    </div>
+    <div class="container">
+        <h1>Plugin Management</h1>
+		{{if .Message}}
+		<div class="message">{{.Message}}</div>
+		{{end}}
+        {{range .Plugins}}
+        <div class="card">
+            <h2>{{.Name}}</h2>
+            <form action="/api/plugins/config" method="post">
+                <input type="hidden" name="pluginName" value="{{.Name}}">
+                {{range .GetConfigFields}}
+                <div class="form-group">
+                    <label for="{{.Name}}">{{.Description}}</label>
+                    {{if eq .Type "textarea"}}
+                    <textarea id="{{.Name}}" name="{{.Name}}" rows="5">{{.Value}}</textarea>
+                    {{else}}
+                    <input type="{{.Type}}" id="{{.Name}}" name="{{.Name}}" value="{{.Value}}">
+                    {{end}}
+                </div>
+                {{end}}
+                <button type="submit" class="btn">Save Configuration</button>
+            </form>
+        </div>
+        {{end}}
+    </div>
+</body>
+</html>
+`
+
 const statsPage = `
 <!DOCTYPE html>
 <html lang="en">
@@ -263,7 +429,7 @@ const statsPage = `
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ASTRACAT DNS - Dashboard</title>
-	<meta http-equiv="refresh" content="10">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background-color: #f0f2f5; color: #333; }
         .navbar { background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center; }
@@ -297,12 +463,35 @@ const statsPage = `
 		{{end}}
         <div class="card">
             <h2>Statistics</h2>
-			<div class="stats-grid">
-				<div class="stat-item">
-					<div class="value">{{.Queries}}</div>
-					<div class="label">Total Queries</div>
-				</div>
-			</div>
+            <div class="stats-grid">
+                <div class="stat-item">
+                    <div class="value" id="total-queries">{{.Queries}}</div>
+                    <div class="label">Total Queries</div>
+                </div>
+                <div class="stat-item">
+                    <div class="value" id="qps">0</div>
+                    <div class="label">QPS</div>
+                </div>
+                <div class="stat-item">
+                    <div class="value" id="cache-hit-rate">0%</div>
+                    <div class="label">Cache Hit Rate</div>
+                </div>
+                <div class="stat-item">
+                    <div class="value" id="cpu-usage">0%</div>
+                    <div class="label">CPU Usage</div>
+                </div>
+                <div class="stat-item">
+                    <div class="value" id="memory-usage">0%</div>
+                    <div class="label">Memory Usage</div>
+                </div>
+                <div class="stat-item">
+                    <div class="value" id="goroutines">0</div>
+                    <div class="label">Goroutines</div>
+                </div>
+            </div>
+            <div style="width: 100%; margin-top: 2rem;">
+                <canvas id="qpsChart"></canvas>
+            </div>
         </div>
         <div class="card">
             <h2>Settings</h2>
@@ -341,6 +530,60 @@ const statsPage = `
 			</ul>
 		</div>
     </div>
+    <script>
+        const qpsData = {
+            labels: [],
+            datasets: [{
+                label: 'QPS',
+                data: [],
+                borderColor: 'rgb(75, 192, 192)',
+                tension: 0.1,
+                fill: false
+            }]
+        };
+
+        const qpsChart = new Chart(document.getElementById('qpsChart'), {
+            type: 'line',
+            data: qpsData,
+            options: {
+                scales: {
+                    x: {
+                        type: 'time',
+                        time: {
+                            unit: 'second'
+                        }
+                    }
+                }
+            }
+        });
+
+        function updateMetrics() {
+            fetch('/api/metrics')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('total-queries').innerText = data.total_queries;
+                    document.getElementById('qps').innerText = data.qps.toFixed(2);
+                    document.getElementById('cache-hit-rate').innerText = data.cache_hit_rate.toFixed(2) + '%';
+                    document.getElementById('cpu-usage').innerText = data.cpu_usage.toFixed(2) + '%';
+                    document.getElementById('memory-usage').innerText = data.memory_usage.toFixed(2) + '%';
+                    document.getElementById('goroutines').innerText = data.goroutines;
+
+                    const now = new Date();
+                    qpsData.labels.push(now);
+                    qpsData.datasets[0].data.push(data.qps);
+
+                    if (qpsData.labels.length > 60) {
+                        qpsData.labels.shift();
+                        qpsData.datasets[0].data.shift();
+                    }
+
+                    qpsChart.update();
+                });
+        }
+
+        setInterval(updateMetrics, 2000);
+        updateMetrics(); // Initial call
+    </script>
 </body>
 </html>
 `

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -18,7 +18,7 @@ func newTestCache(t *testing.T) (*Cache, func()) {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	cache := NewCache(128, 1, dir, m)
 
 	cleanup := func() {
@@ -104,7 +104,7 @@ func TestCachePersistence(t *testing.T) {
 	key := Key(q)
 	msg := createTestMsg("persistent.com.", 60, "5.6.7.8")
 
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	// Create the first cache, add an item, and close it to persist the data.
 	c1 := NewCache(128, 1, dir, m)
 	c1.Set(key, msg, 0)
@@ -138,7 +138,7 @@ func TestCachePersistenceExpiration(t *testing.T) {
 	key := Key(q)
 	msg := createTestMsg("expired-persistent.com.", 1, "9.8.7.6") // 1-second TTL
 
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	// Create the first cache, add an item, and close it.
 	c1 := NewCache(128, 1, dir, m)
 	c1.Set(key, msg, 0)
@@ -198,7 +198,7 @@ func TestCacheStaleWhileRevalidate(t *testing.T) {
 }
 
 func BenchmarkCacheSet(b *testing.B) {
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	dir, err := os.MkdirTemp("", "bench-lmdb-set")
 	if err != nil {
 		b.Fatalf("Failed to create temp dir: %v", err)
@@ -218,7 +218,7 @@ func BenchmarkCacheSet(b *testing.B) {
 }
 
 func BenchmarkCacheGet(b *testing.B) {
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	dir, err := os.MkdirTemp("", "bench-lmdb-get")
 	if err != nil {
 		b.Fatalf("Failed to create temp dir: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,9 @@ type Config struct {
 
 	// Admin panel settings
 	AdminAddr string
+
+	// Metrics storage settings
+	MetricsStoragePath string
 }
 
 // NewConfig returns a new Config with default values.
@@ -49,5 +52,6 @@ func NewConfig() *Config {
 		HostsEnabled:         true,
 		HostsPath:            "hosts",
 		AdminAddr:            "0.0.0.0:8080",
+		MetricsStoragePath:   "/tmp/dns_metrics.json",
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"sync"
@@ -64,19 +65,19 @@ type Metrics struct {
 	sync.RWMutex
 	totalQueries      int64
 	startTime         time.Time
-	topNXDomains      sync.Map // map[string]int64
-	topLatencyDomains sync.Map // map[string]LatencyStat
-	queryTypes        sync.Map // map[string]int64
-	responseCodes     sync.Map // map[string]int64
+	TopNXDomains      sync.Map // map[string]int64
+	TopLatencyDomains sync.Map // map[string]LatencyStat
+	QueryTypes        sync.Map // map[string]int64
+	ResponseCodes     sync.Map // map[string]int64
 	registry          *prometheus.Registry
 
 	// Fields for direct access by JSON handler
-	qps            float64
-	cpuUsage       float64
-	memoryUsage    float64
-	goroutineCount int
-	cacheHits      int64
-	cacheMisses    int64
+	QPS            float64
+	CPUUsage       float64
+	MemoryUsage    float64
+	Goroutines     int
+	CacheHits      int64
+	CacheMisses    int64
 }
 
 var (
@@ -173,22 +174,75 @@ var (
 	})
 )
 
+// HistoricalData holds metrics that are persisted.
+type HistoricalData struct {
+	TotalQueries int64 `json:"total_queries"`
+}
+
 // NewMetrics returns the singleton instance of Metrics.
-func NewMetrics() *Metrics {
+func NewMetrics(storagePath string) *Metrics {
 	once.Do(func() {
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 		registry.MustRegister(prometheus.NewGoCollector())
-		
+
 		instance = &Metrics{
 			startTime: time.Now(),
 			registry:  registry,
 		}
+
+		// Load historical data
+		if err := instance.loadHistoricalData(storagePath); err != nil {
+			log.Printf("Could not load historical metrics: %v", err)
+		}
+
+		// Save historical data on shutdown
+		// This requires a signal handler in main.go to call SaveHistoricalData
 		go instance.qpsCalculator()
 		go instance.systemMetricsCollector()
 		go instance.topDomainsProcessor()
 	})
 	return instance
+}
+
+// loadHistoricalData loads metrics from a file.
+func (m *Metrics) loadHistoricalData(path string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No historical data yet
+		}
+		return err
+	}
+
+	var historicalData HistoricalData
+	if err := json.Unmarshal(data, &historicalData); err != nil {
+		return err
+	}
+
+	m.totalQueries = historicalData.TotalQueries
+	promTotalQueries.Add(float64(m.totalQueries))
+	return nil
+}
+
+// SaveHistoricalData saves metrics to a file.
+func (m *Metrics) SaveHistoricalData(path string) error {
+	m.RLock()
+	defer m.RUnlock()
+
+	historicalData := HistoricalData{
+		TotalQueries: m.totalQueries,
+	}
+
+	data, err := json.Marshal(historicalData)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
 }
 
 // StartMetricsServer starts an HTTP server for Prometheus metrics.
@@ -226,7 +280,7 @@ func (m *Metrics) jsonMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	defer m.RUnlock()
 
 	var topNXDomains []DomainCount
-	m.topNXDomains.Range(func(key, value interface{}) bool {
+	m.TopNXDomains.Range(func(key, value interface{}) bool {
 		topNXDomains = append(topNXDomains, DomainCount{Domain: key.(string), Count: value.(int64)})
 		return true
 	})
@@ -236,7 +290,7 @@ func (m *Metrics) jsonMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var topLatencyDomains []DomainLatency
-	m.topLatencyDomains.Range(func(key, value interface{}) bool {
+	m.TopLatencyDomains.Range(func(key, value interface{}) bool {
 		stat := value.(LatencyStat)
 		if stat.Count > 0 {
 			avgLatency := stat.TotalLatency.Seconds() * 1000 / float64(stat.Count)
@@ -250,32 +304,32 @@ func (m *Metrics) jsonMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var queryTypes []TypeCount
-	m.queryTypes.Range(func(key, value interface{}) bool {
+	m.QueryTypes.Range(func(key, value interface{}) bool {
 		queryTypes = append(queryTypes, TypeCount{Type: key.(string), Count: value.(int64)})
 		return true
 	})
 	sort.Slice(queryTypes, func(i, j int) bool { return queryTypes[i].Count > queryTypes[j].Count })
 
 	var responseCodes []CodeCount
-	m.responseCodes.Range(func(key, value interface{}) bool {
+	m.ResponseCodes.Range(func(key, value interface{}) bool {
 		responseCodes = append(responseCodes, CodeCount{Code: key.(string), Count: value.(int64)})
 		return true
 	})
 	sort.Slice(responseCodes, func(i, j int) bool { return responseCodes[i].Count > responseCodes[j].Count })
 
 	var cacheHitRate float64
-	if m.cacheHits+m.cacheMisses > 0 {
-		cacheHitRate = float64(m.cacheHits) / float64(m.cacheHits+m.cacheMisses) * 100
+	if m.CacheHits+m.CacheMisses > 0 {
+		cacheHitRate = float64(m.CacheHits) / float64(m.CacheHits+m.CacheMisses) * 100
 	}
 
 	data := DashboardMetrics{
-		QPS:               m.qps,
+		QPS:               m.QPS,
 		TotalQueries:      m.totalQueries,
-		CPUUsage:          m.cpuUsage,
-		MemoryUsage:       m.memoryUsage,
-		Goroutines:        m.goroutineCount,
-		CacheHits:         m.cacheHits,
-		CacheMisses:       m.cacheMisses,
+		CPUUsage:          m.CPUUsage,
+		MemoryUsage:       m.MemoryUsage,
+		Goroutines:        m.Goroutines,
+		CacheHits:         m.CacheHits,
+		CacheMisses:       m.CacheMisses,
 		CacheHitRate:      cacheHitRate,
 		TopNXDomains:      topNXDomains,
 		TopLatencyDomains: topLatencyDomains,
@@ -316,7 +370,7 @@ func (m *Metrics) qpsCalculator() {
 		currentQueries := m.totalQueries
 		qps := float64(currentQueries - lastQueryCount)
 		lastQueryCount = currentQueries
-		m.qps = qps
+		m.QPS = qps
 		m.Unlock()
 		promQPS.Set(qps)
 	}
@@ -332,20 +386,20 @@ func (m *Metrics) systemMetricsCollector() {
 		// CPU Usage
 		cpuPercentages, err := cpu.Percent(0, false)
 		if err == nil && len(cpuPercentages) > 0 {
-			m.cpuUsage = cpuPercentages[0]
+			m.CPUUsage = cpuPercentages[0]
 			promCPUUsage.Set(cpuPercentages[0])
 		}
 
 		// Memory Usage
 		memInfo, err := mem.VirtualMemory()
 		if err == nil {
-			m.memoryUsage = memInfo.UsedPercent
+			m.MemoryUsage = memInfo.UsedPercent
 			promMemoryUsage.Set(memInfo.UsedPercent)
 		}
 
 		// Goroutine Count
-		m.goroutineCount = runtime.NumGoroutine()
-		promGoroutineCount.Set(float64(m.goroutineCount))
+		m.Goroutines = runtime.NumGoroutine()
+		promGoroutineCount.Set(float64(m.Goroutines))
 
 		m.Unlock()
 
@@ -370,17 +424,17 @@ func (m *Metrics) UpdateCacheStats(probation, protected int) {
 
 // RecordNXDOMAIN records an NXDOMAIN response for a given domain.
 func (m *Metrics) RecordNXDOMAIN(domain string) {
-	val, _ := m.topNXDomains.LoadOrStore(domain, int64(0))
-	m.topNXDomains.Store(domain, val.(int64)+1)
+	val, _ := m.TopNXDomains.LoadOrStore(domain, int64(0))
+	m.TopNXDomains.Store(domain, val.(int64)+1)
 }
 
 // RecordLatency records the query latency for a given domain.
 func (m *Metrics) RecordLatency(domain string, latency time.Duration) {
-	val, _ := m.topLatencyDomains.LoadOrStore(domain, LatencyStat{})
+	val, _ := m.TopLatencyDomains.LoadOrStore(domain, LatencyStat{})
 	stat := val.(LatencyStat)
 	stat.TotalLatency += latency
 	stat.Count++
-	m.topLatencyDomains.Store(domain, stat)
+	m.TopLatencyDomains.Store(domain, stat)
 }
 
 // topDomainsProcessor periodically processes the domain maps to generate top lists.
@@ -399,7 +453,7 @@ func (m *Metrics) processTopNXDomains() {
 		Domain string
 		Count  int64
 	}
-	m.topNXDomains.Range(func(key, value interface{}) bool {
+	m.TopNXDomains.Range(func(key, value interface{}) bool {
 		domains = append(domains, struct {
 			Domain string
 			Count  int64
@@ -431,7 +485,7 @@ func (m *Metrics) processTopLatencyDomains() {
 		Domain     string
 		AvgLatency float64
 	}
-	m.topLatencyDomains.Range(func(key, value interface{}) bool {
+	m.TopLatencyDomains.Range(func(key, value interface{}) bool {
 		stat := value.(LatencyStat)
 		if stat.Count > 0 {
 			avgLatency := stat.TotalLatency.Seconds() * 1000 / float64(stat.Count) // avg in ms
@@ -463,15 +517,15 @@ func (m *Metrics) processTopLatencyDomains() {
 
 // RecordQueryType records the type of a DNS query.
 func (m *Metrics) RecordQueryType(qtype string) {
-	val, _ := m.queryTypes.LoadOrStore(qtype, int64(0))
-	m.queryTypes.Store(qtype, val.(int64)+1)
+	val, _ := m.QueryTypes.LoadOrStore(qtype, int64(0))
+	m.QueryTypes.Store(qtype, val.(int64)+1)
 	promQueryTypes.WithLabelValues(qtype).Inc()
 }
 
 // RecordResponseCode records the response code of a DNS query.
 func (m *Metrics) RecordResponseCode(rcode string) {
-	val, _ := m.responseCodes.LoadOrStore(rcode, int64(0))
-	m.responseCodes.Store(rcode, val.(int64)+1)
+	val, _ := m.ResponseCodes.LoadOrStore(rcode, int64(0))
+	m.ResponseCodes.Store(rcode, val.(int64)+1)
 	promResponseCodes.WithLabelValues(rcode).Inc()
 }
 
@@ -493,7 +547,7 @@ func (m *Metrics) IncrementCacheRevalidations() {
 // IncrementCacheHits increments the cache hit counter.
 func (m *Metrics) IncrementCacheHits() {
 	m.Lock()
-	m.cacheHits++
+	m.CacheHits++
 	m.Unlock()
 	promCacheHits.Inc()
 }
@@ -501,7 +555,7 @@ func (m *Metrics) IncrementCacheHits() {
 // IncrementCacheMisses increments the cache miss counter.
 func (m *Metrics) IncrementCacheMisses() {
 	m.Lock()
-	m.cacheMisses++
+	m.CacheMisses++
 	m.Unlock()
 	promCacheMisses.Inc()
 }

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -13,12 +13,23 @@ type PluginContext struct {
 	ResponseWriter dns.ResponseWriter
 }
 
+// ConfigField defines a configurable field for a plugin.
+type ConfigField struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"` // e.g., "text", "number", "boolean"
+	Value       any    `json:"value"`
+}
+
 // Plugin is the interface that all plugins must implement.
 type Plugin interface {
 	Name() string
 	// Execute processes a DNS message. It returns true if it has handled the
 	// message and no further processing should be done.
 	Execute(ctx *PluginContext, w dns.ResponseWriter, r *dns.Msg) (bool, error)
+	GetConfig() map[string]any
+	SetConfig(config map[string]any) error
+	GetConfigFields() []ConfigField
 }
 
 // PluginManager manages the lifecycle of plugins.
@@ -51,4 +62,19 @@ func (pm *PluginManager) ExecutePlugins(ctx *PluginContext, w dns.ResponseWriter
 		}
 	}
 	return false
+}
+
+// GetPlugins returns all registered plugins.
+func (pm *PluginManager) GetPlugins() []Plugin {
+	return pm.plugins
+}
+
+// GetPlugin returns a plugin by name.
+func (pm *PluginManager) GetPlugin(name string) Plugin {
+	for _, p := range pm.plugins {
+		if p.Name() == name {
+			return p
+		}
+	}
+	return nil
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -20,7 +20,7 @@ func TestResolver_Resolve(t *testing.T) {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	c := cache.NewCache(cache.DefaultCacheSize, cache.DefaultShards, dir, m)
 	defer c.Close()
 	r, err := NewResolver(ResolverTypeDnslib, cfg, c, m)
@@ -74,7 +74,7 @@ func TestResolver_Resolve_DNSSEC(t *testing.T) {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics("")
 	c := cache.NewCache(cache.DefaultCacheSize, cache.DefaultShards, dir, m)
 	defer c.Close()
 	r, err := NewResolver(ResolverTypeDnslib, cfg, c, m)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"os/signal"
 
 	"dns-resolver/internal/cache"
 	"dns-resolver/internal/config"
@@ -23,23 +24,14 @@ import (
 // Старая функция больше не используется, так как теперь используем метод из пакета metrics
 
 func main() {
-	// Open a file for logging. Truncate the file if it already exists.
-	logFile, err := os.OpenFile("server.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
-	if err != nil {
-		log.Fatalf("Failed to open log file: %v", err)
-	}
-	defer logFile.Close()
-
-	// Set the output of the log package to the file.
-	log.SetOutput(logFile)
-
+	log.SetOutput(os.Stdout)
 	log.Println("Booting up ASTRACAT Relover...")
 
 	// Load configuration
 	cfg := config.NewConfig()
 
 	// Initialize metrics
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics(cfg.MetricsStoragePath)
 
 	// Create cache and resolver
 	c := cache.NewCache(cfg.CacheSize, cache.DefaultShards, cfg.LMDBPath, m)
@@ -80,12 +72,24 @@ func main() {
 
 	// Start the admin server
 	if cfg.AdminAddr != "" {
-		adminServer := admin.New(cfg.AdminAddr, m, hostsPlugin, adBlockPlugin)
+		adminServer := admin.New(cfg.AdminAddr, m, hostsPlugin, adBlockPlugin, pm)
 		go adminServer.Start()
 	}
 
 	// Create and start the server
 	srv := server.NewServer(cfg, m, res, pm)
+
+	// Graceful shutdown
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt)
+		<-sig
+		log.Println("Shutting down...")
+		if err := m.SaveHistoricalData(cfg.MetricsStoragePath); err != nil {
+			log.Printf("Failed to save metrics: %v", err)
+		}
+		os.Exit(0)
+	}()
 
 	srv.ListenAndServe()
 }

--- a/plugins/adblock/adblock.go
+++ b/plugins/adblock/adblock.go
@@ -134,3 +134,51 @@ func (p *AdBlockPlugin) UpdateBlocklists() {
 	p.mu.Unlock()
 	log.Printf("Adblock plugin updated with %d domains.", len(p.blocked))
 }
+
+// GetConfig returns the current configuration of the plugin.
+func (p *AdBlockPlugin) GetConfig() map[string]any {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return map[string]any{
+		"blocklists":     p.blocklists,
+		"updateInterval": p.updateInterval.String(),
+	}
+}
+
+// SetConfig updates the configuration of the plugin.
+func (p *AdBlockPlugin) SetConfig(config map[string]any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if blocklists, ok := config["blocklists"].(string); ok {
+		p.blocklists = strings.Split(blocklists, "\n")
+	}
+
+	if updateInterval, ok := config["updateInterval"].(string); ok {
+		duration, err := time.ParseDuration(updateInterval)
+		if err != nil {
+			return err
+		}
+		p.updateInterval = duration
+	}
+
+	return nil
+}
+
+// GetConfigFields returns the configuration fields of the plugin.
+func (p *AdBlockPlugin) GetConfigFields() []plugins.ConfigField {
+	return []plugins.ConfigField{
+		{
+			Name:        "blocklists",
+			Description: "List of blocklist URLs (one per line)",
+			Type:        "textarea",
+			Value:       strings.Join(p.GetBlocklists(), "\n"),
+		},
+		{
+			Name:        "updateInterval",
+			Description: "Update interval for blocklists (e.g., '1h', '30m')",
+			Type:        "text",
+			Value:       p.updateInterval.String(),
+		},
+	}
+}

--- a/plugins/example_logger/logger.go
+++ b/plugins/example_logger/logger.go
@@ -28,3 +28,18 @@ func (p *LoggerPlugin) Execute(ctx *plugins.PluginContext, w dns.ResponseWriter,
 func New() *LoggerPlugin {
 	return &LoggerPlugin{}
 }
+
+// GetConfig returns the current configuration of the plugin.
+func (p *LoggerPlugin) GetConfig() map[string]any {
+	return nil
+}
+
+// SetConfig updates the configuration of the plugin.
+func (p *LoggerPlugin) SetConfig(config map[string]any) error {
+	return nil
+}
+
+// GetConfigFields returns the configuration fields of the plugin.
+func (p *LoggerPlugin) GetConfigFields() []plugins.ConfigField {
+	return nil
+}

--- a/plugins/hosts/hosts.go
+++ b/plugins/hosts/hosts.go
@@ -117,5 +117,41 @@ func (p *HostsPlugin) Execute(ctx *plugins.PluginContext, w dns.ResponseWriter, 
 
 	r.Answer = append(r.Answer, rr)
 	r.Rcode = dns.RcodeSuccess
+	w.WriteMsg(r)
 	return true, nil
+}
+
+// GetConfig returns the current configuration of the plugin.
+func (p *HostsPlugin) GetConfig() map[string]any {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return map[string]any{
+		"filePath": p.filePath,
+	}
+}
+
+// SetConfig updates the configuration of the plugin.
+func (p *HostsPlugin) SetConfig(config map[string]any) error {
+	if filePath, ok := config["filePath"].(string); ok {
+		p.mu.Lock()
+		p.filePath = filePath
+		p.mu.Unlock()
+		// Reload the hosts file with the new path
+		return p.Reload()
+	}
+	return nil
+}
+
+// GetConfigFields returns the configuration fields of the plugin.
+func (p *HostsPlugin) GetConfigFields() []plugins.ConfigField {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return []plugins.ConfigField{
+		{
+			Name:        "filePath",
+			Description: "Path to the hosts file",
+			Type:        "text",
+			Value:       p.filePath,
+		},
+	}
 }

--- a/plugins/ratelimit/ratelimit.go
+++ b/plugins/ratelimit/ratelimit.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"dns-resolver/internal/plugins"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -86,5 +87,76 @@ func (p *RateLimitPlugin) cleanupVisitors() {
 			}
 		}
 		p.mu.Unlock()
+	}
+}
+
+// GetConfig returns the current configuration of the plugin.
+func (p *RateLimitPlugin) GetConfig() map[string]any {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return map[string]any{
+		"rate":          p.rate,
+		"burst":         p.burst,
+		"cleanupInterval": p.cleanupInterval.String(),
+	}
+}
+
+// SetConfig updates the configuration of the plugin.
+func (p *RateLimitPlugin) SetConfig(config map[string]any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if rateStr, ok := config["rate"].(string); ok {
+		if rateLimit, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			p.rate = rate.Limit(rateLimit)
+		}
+	}
+
+	if burstStr, ok := config["burst"].(string); ok {
+		if burst, err := strconv.Atoi(burstStr); err == nil {
+			p.burst = burst
+		}
+	}
+
+	if cleanupInterval, ok := config["cleanupInterval"].(string); ok {
+		duration, err := time.ParseDuration(cleanupInterval)
+		if err != nil {
+			return err
+		}
+		p.cleanupInterval = duration
+	}
+
+	// Update existing limiters
+	for _, v := range p.visitors {
+		v.limiter.SetLimit(p.rate)
+		v.limiter.SetBurst(p.burst)
+	}
+
+	return nil
+}
+
+// GetConfigFields returns the configuration fields of the plugin.
+func (p *RateLimitPlugin) GetConfigFields() []plugins.ConfigField {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return []plugins.ConfigField{
+		{
+			Name:        "rate",
+			Description: "Rate limit (queries per second)",
+			Type:        "number",
+			Value:       p.rate,
+		},
+		{
+			Name:        "burst",
+			Description: "Burst size",
+			Type:        "number",
+			Value:       p.burst,
+		},
+		{
+			Name:        "cleanupInterval",
+			Description: "Cleanup interval for visitors (e.g., '1m', '30s')",
+			Type:        "text",
+			Value:       p.cleanupInterval.String(),
+		},
 	}
 }


### PR DESCRIPTION
Добавляет в веб-панель расширенную статистику, включая QPS, использование CPU, кеш-хитрейт и другие метрики. Реализовано сохранение общего количества запросов между перезапусками.

Добавлен новый раздел "Plugins", который позволяет просматривать и изменять конфигурацию плагинов в реальном времени через веб-интерфейс.

Основные изменения:
- Расширен интерфейс плагинов для поддержки динамической конфигурации.
- Реализована страница плагинов в админ-панели с формами для редактирования.
- Добавлена новая страница статистики с графиком QPS.
- Реализован механизм сохранения и загрузки статистики.
- Исправлены ошибки, выявленные в ходе код-ревью.