### PR TITLE
feat: normalize SSL cert env content before writing files

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -142,6 +142,69 @@ The admin node will expose a sync endpoint at:
    docker run -d --name dns -p 5053:53/udp -p 5053:53/tcp astracat-dns
    ```
 
+### 🧩 Docker Compose (docker-compose.yml) — пример для Docker YML
+
+Ниже пример сервиса в формате `docker-compose.yml`, который использует все основные порты и переменные окружения.  
+Вы можете вставить блок в свой `services:` и запустить через `docker compose up -d`.
+
+```yaml
+services:
+  astracat-dns:
+    build: .
+    image: astracat/astracat-dns
+    container_name: astracat-dns
+
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+      - "443:443/tcp"
+      - "853:853/tcp"
+      - "9090:9090/tcp"
+      - "8080:8080/tcp"
+
+    environment:
+      LISTEN_ADDR: 0.0.0.0:53
+      METRICS_ADDR: 0.0.0.0:9090
+      ADMIN_ADDR: 0.0.0.0:8080
+      DOH_ADDR: 0.0.0.0:443
+      DOT_ADDR: 0.0.0.0:853
+
+      CACHE_SIZE: "1024"
+      CACHE_RAM_SIZE: "50"
+      MAX_WORKERS: "10"
+      GOMAXPROCS: "1"
+
+      ADBLOCK_ENABLED: "true"
+      HOSTS_ENABLED: "true"
+
+      # ===== SSL CERTIFICATE (FULLCHAIN) =====
+      SSL_CERT_CONTENT: |
+        -----BEGIN CERTIFICATE-----
+        ...ваш fullchain.pem...
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        ...промежуточный сертификат (если есть)...
+        -----END CERTIFICATE-----
+
+      # ===== SSL PRIVATE KEY =====
+      SSL_KEY_CONTENT: |
+        -----BEGIN PRIVATE KEY-----
+        ...ваш privkey.pem...
+        -----END PRIVATE KEY-----
+
+    restart: always
+```
+
+**Запуск:**
+```bash
+docker compose up -d
+```
+
+**Примечания:**
+- `SSL_CERT_CONTENT` и `SSL_KEY_CONTENT` должны содержать полный текст сертификатов.  
+- При запуске контейнера содержимое будет записано в `cert.pem` и `key.pem`.  
+- Если вам не нужен DoH/DoT, можно удалить соответствующие порты и переменные (`DOH_ADDR`, `DOT_ADDR`).
+
 ---
 
 ## ☁️ Pushing to Docker Hub

--- a/internal/config/certs.go
+++ b/internal/config/certs.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func (c *Config) WriteCertFilesFromEnv() (bool, error) {
+	if c.CertContent == "" && c.KeyContent == "" {
+		return false, nil
+	}
+	if c.CertContent == "" || c.KeyContent == "" {
+		return false, fmt.Errorf("both SSL_CERT_CONTENT and SSL_KEY_CONTENT must be set")
+	}
+
+	certContent, err := normalizePEM(c.CertContent, "certificate")
+	if err != nil {
+		return false, err
+	}
+	keyContent, err := normalizePEM(c.KeyContent, "private key")
+	if err != nil {
+		return false, err
+	}
+
+	certPath := c.CertFile
+	if certPath == "" {
+		certPath = "cert.pem"
+	}
+	keyPath := c.KeyFile
+	if keyPath == "" {
+		keyPath = "key.pem"
+	}
+
+	if err := os.WriteFile(certPath, []byte(certContent), 0644); err != nil {
+		return false, fmt.Errorf("write cert file: %w", err)
+	}
+	if err := os.WriteFile(keyPath, []byte(keyContent), 0600); err != nil {
+		return false, fmt.Errorf("write key file: %w", err)
+	}
+
+	c.CertFile = certPath
+	c.KeyFile = keyPath
+	return true, nil
+}
+
+func normalizePEM(value string, label string) (string, error) {
+	normalized := strings.TrimSpace(value)
+	if strings.Contains(normalized, "\\n") && !strings.Contains(normalized, "\n") {
+		normalized = strings.ReplaceAll(normalized, "\\n", "\n")
+	}
+	if !strings.Contains(normalized, "BEGIN ") {
+		compact := strings.ReplaceAll(normalized, "\n", "")
+		compact = strings.ReplaceAll(compact, "\r", "")
+		compact = strings.ReplaceAll(compact, " ", "")
+		decoded, err := base64.StdEncoding.DecodeString(compact)
+		if err == nil {
+			normalized = strings.TrimSpace(string(decoded))
+		}
+	}
+	if !strings.Contains(normalized, "BEGIN ") {
+		return "", fmt.Errorf("%s content is not valid PEM", label)
+	}
+	return normalized, nil
+}

--- a/main.go
+++ b/main.go
@@ -77,32 +77,11 @@ func main() {
 	}
 
 	// 3. Handle Certificate Content from Env Vars
-	// This supports "Upload image to git and accept certs as text" request.
-	if cfg.CertContent != "" && cfg.KeyContent != "" {
-		log.Println("Detected SSL certificates in environment variables. Writing to files...")
-		// Use configured paths or defaults
-		certPath := cfg.CertFile
-		if certPath == "" {
-			certPath = "cert.pem"
-		}
-		keyPath := cfg.KeyFile
-		if keyPath == "" {
-			keyPath = "key.pem"
-		}
-
-		if err := os.WriteFile(certPath, []byte(cfg.CertContent), 0644); err != nil {
-			log.Printf("Error writing cert file from env: %v", err)
-		} else {
-			cfg.CertFile = certPath
-			log.Printf("Wrote certificate to %s", certPath)
-		}
-
-		if err := os.WriteFile(keyPath, []byte(cfg.KeyContent), 0600); err != nil {
-			log.Printf("Error writing key file from env: %v", err)
-		} else {
-			cfg.KeyFile = keyPath
-			log.Printf("Wrote private key to %s", keyPath)
-		}
+	wroteCerts, err := cfg.WriteCertFilesFromEnv()
+	if err != nil {
+		log.Printf("Failed to write certificates from env: %v", err)
+	} else if wroteCerts {
+		log.Printf("Wrote SSL certificates to %s and %s", cfg.CertFile, cfg.KeyFile)
 	} else {
 		log.Println("No certificate content in environment variables.")
 	}


### PR DESCRIPTION
### Motivation
- Improve reliability when certificates are provided via environment variables (`SSL_CERT_CONTENT` / `SSL_KEY_CONTENT`) so containers / docker-compose deployments can pass PEM as escaped strings or base64 blobs.
- Centralize and harden the logic that writes env-provided certs to disk to avoid duplicated logic and unclear error handling in `main.go`.

### Description
- Add `internal/config/certs.go` with `Config.WriteCertFilesFromEnv()` which normalizes input (unescape `\n`, support base64-encoded PEM, validate presence of `BEGIN ` markers) and writes to `cert.pem`/`key.pem` or configured `CertFile`/`KeyFile` paths.
- Replace inline env-to-file logic in `main.go` with a call to `cfg.WriteCertFilesFromEnv()` and improve logging to report success or detailed failure.
- Ensure the helper returns a boolean for whether files were written and clear errors when only one of the variables is set.

### Testing
- No automated tests were executed as part of this change; behavior was implemented and structured to be unit-testable (suggest running `go test ./...` and `go build` in CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69753810294c832880d9a60a9a9b4202)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker Compose deployment example with complete service configuration, including environment variables, SSL certificate setup, port configuration, restart policies, and usage instructions.

* **Improvements**
  * Strengthened SSL certificate management with improved validation and support for automated provisioning from environment variables with proper error handling and content normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->