### PR TITLE
Use configurable Unbound trust anchor path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,9 @@ stale_while_revalidate: 1m
 # Resolving Strategy: "knot" (uses dnslib) or "unbound" (if implemented)
 resolver_type: "knot"
 
+# Path to the DNSSEC root trust anchor for Unbound.
+root_anchor_path: "/var/lib/unbound/root.key"
+
 # ------------------------------------------------------------------------------
 # Plugins
 # ------------------------------------------------------------------------------

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -372,7 +372,7 @@ func (s *Server) handleControlReload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.resolver != nil {
-		if err := s.resolver.Reload(); err != nil {
+		if err := s.resolver.Reload(s.rootAnchorPath()); err != nil {
 			log.Printf("Reload failed: %v", err)
 			http.Error(w, "Failed to reload: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -390,7 +390,7 @@ func (s *Server) handleControlCacheClear(w http.ResponseWriter, r *http.Request)
 	}
 
 	if s.resolver != nil {
-		if err := s.resolver.ClearCache(); err != nil {
+		if err := s.resolver.ClearCache(s.rootAnchorPath()); err != nil {
 			log.Printf("Cache clear failed: %v", err)
 			http.Error(w, "Failed to clear cache: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -399,4 +399,11 @@ func (s *Server) handleControlCacheClear(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "message": "Cache cleared"})
+}
+
+func (s *Server) rootAnchorPath() string {
+	if s.baseConfig != nil {
+		return s.baseConfig.RootAnchorPath
+	}
+	return ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,7 +104,7 @@ func NewConfig() *Config {
 		KeyFile:              "",
 		CertContent:          "",
 		KeyContent:           "",
-		RootAnchorPath:       "/opt/homebrew/etc/unbound/root.key", // Default macos path for homebrew unbound
+		RootAnchorPath:       "/var/lib/unbound/root.key",
 		AcmeEnabled:          false,
 		AcmeCacheDir:         "certs-cache",
 		ClusterRole:          "standalone",

--- a/internal/unbound/resolver.go
+++ b/internal/unbound/resolver.go
@@ -15,7 +15,10 @@ type Resolver struct {
 }
 
 // NewResolver creates and initializes a new Unbound resolver.
-func NewResolver() (*Resolver, error) {
+func NewResolver(rootAnchorPath string) (*Resolver, error) {
+	if rootAnchorPath == "" {
+		rootAnchorPath = "/var/lib/unbound/root.key"
+	}
 	u := unbound.New()
 
 	// Apply User Configuration
@@ -29,7 +32,7 @@ func NewResolver() (*Resolver, error) {
 		"harden-glue":            "yes",
 		"harden-dnssec-stripped": "yes",
 		"use-caps-for-id":        "no",
-		"auto-trust-anchor-file": "/var/lib/unbound/root.key",
+		"auto-trust-anchor-file": rootAnchorPath,
 		"val-clean-additional":   "yes",
 		"edns-buffer-size":       "1232",
 		"so-rcvbuf":              "1m",
@@ -153,7 +156,10 @@ func (r *Resolver) Close() {
 }
 
 // Reload re-initializes the Unbound resolver.
-func (r *Resolver) Reload() error {
+func (r *Resolver) Reload(rootAnchorPath string) error {
+	if rootAnchorPath == "" {
+		rootAnchorPath = "/var/lib/unbound/root.key"
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -174,7 +180,7 @@ func (r *Resolver) Reload() error {
 		"harden-glue":            "yes",
 		"harden-dnssec-stripped": "yes",
 		"use-caps-for-id":        "no",
-		"auto-trust-anchor-file": "/var/lib/unbound/root.key",
+		"auto-trust-anchor-file": rootAnchorPath,
 		"val-clean-additional":   "yes",
 		"edns-buffer-size":       "1232",
 		"so-rcvbuf":              "1m",
@@ -211,6 +217,6 @@ func (r *Resolver) Reload() error {
 }
 
 // ClearCache clears the cache by recreating the instance (simplest method for embedded libunbound).
-func (r *Resolver) ClearCache() error {
-	return r.Reload()
+func (r *Resolver) ClearCache(rootAnchorPath string) error {
+	return r.Reload(rootAnchorPath)
 }

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	// 4. Initialize Unbound Resolver
 	log.Println("Initializing Unbound Resolver...")
-	resolver, err := unbound.NewResolver()
+	resolver, err := unbound.NewResolver(cfg.RootAnchorPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize Unbound: %v", err)
 	}


### PR DESCRIPTION
### Motivation
- Unbound was hardcoded to use `/var/lib/unbound/root.key` (previously a macOS default in code), which prevented using a custom DNSSEC trust anchor path from configuration or admin actions.
- Make the trust-anchor path configurable so embedded libunbound can load the correct root key for the environment and admin reload/clear operations.

### Description
- Add `root_anchor_path` to the example `config.yaml` and set the `Config.RootAnchorPath` default to `/var/lib/unbound/root.key` in `internal/config/config.go`.
- Change `unbound.NewResolver()` to `unbound.NewResolver(rootAnchorPath string)` and use the provided path for the `auto-trust-anchor-file` option, defaulting to `/var/lib/unbound/root.key` if empty in `internal/unbound/resolver.go`.
- Change `Resolver.Reload()` and `Resolver.ClearCache()` to accept a `rootAnchorPath` argument and reinitialize Unbound with that path.
- Wire the configured path through the application: pass `cfg.RootAnchorPath` when creating the resolver in `main.go`, and update admin endpoints to call `s.resolver.Reload(s.rootAnchorPath())` and `s.resolver.ClearCache(s.rootAnchorPath())` with a new helper `rootAnchorPath()` in `internal/admin/admin.go`.

### Testing
- No automated tests were run as part of this change.
- Verified repository edits and committed the changes locally; runtime / integration validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69754200e2d08328a71b6358cb87a9b6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable DNSSEC root trust anchor path option, allowing users to specify the location of the root anchor file for DNS resolver operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->